### PR TITLE
Update docs to include branch option for vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Plugin 'thesis/vim-solidity'
 Add the following line to your `~/.vimrc`:
 
 ```vim
-Plug 'thesis/vim-solidity'
+Plug 'thesis/vim-solidity', {'branch': 'main' }
 ```
 
 ### No Plugin Manager


### PR DESCRIPTION
## Summary

The forked repo uses the `main` branch Gitflow workflow which differs from the forked repo's `master` branch. The alternative `main` branch causes a "branch not found" warning when installing with `:PlugInstall`. The fix for this is to either use the `master` branch or add a branch option to the install line for vim-plug users.

This PR chooses to use the latter strategy which is similar to [coc.vim](https://github.com/neoclide/coc.nvim#quick-start)'s install instructions.