### PR TITLE
Add @custom:* NatSpec tag highlighting

### DIFF
--- a/syntax/solidity.vim
+++ b/syntax/solidity.vim
@@ -165,7 +165,7 @@ hi def link solEventArgSpecial   Label
 
 " Comment
 syn keyword solCommentTodo       TODO FIXME XXX TBD contained
-syn match solNatSpec             contained /@title\|@author\|@notice\|@dev\|@param\|@inheritdoc\|@return/
+syn match solNatSpec             contained /@title\|@author\|@notice\|@dev\|@param\|@inheritdoc\|@return\|@custom:\w\+/
 syn region  solLineComment       start=+\/\/+ end=+$+ contains=solCommentTodo,solNatSpec,@Spell
 syn region  solLineComment       start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$+ contains=solCommentTodo,solNatSpec,@Spell fold
 syn region  solComment           start="/\*"  end="\*/" contains=solCommentTodo,solNatSpec,@Spell fold


### PR DESCRIPTION
Solidity supports `@custom:` NatSpec tags (e.g. `@custom:oz-upgrades`, `@custom:smtchecker`) since v0.6.2. This adds them to the existing solNatSpec match pattern so they highlight consistently with `@title`, `@author`, `@notice`, etc.